### PR TITLE
feat(ci): add daily health check workflow

### DIFF
--- a/.github/workflows/healthcheck.yml
+++ b/.github/workflows/healthcheck.yml
@@ -1,0 +1,16 @@
+name: Health Check
+
+on:
+  schedule:
+    # Runs once a day at midnight UTC.
+    - cron: '0 0 * * *'
+
+jobs:
+  health_check_job:
+    runs-on: ubuntu-24.04
+    name: Check health of the deployed application
+    steps:
+      - name: URL Health Check
+        uses: jtalk/url-health-check-action@v4
+        with:
+          url: https://pokedex-app-6035.fly.dev/


### PR DESCRIPTION
This commit introduces a new GitHub Actions workflow (`healthcheck.yml`) to perform periodic health checks on the deployed application.

The workflow runs once every 24 hours, sending a request to the application URL. This helps to proactively monitor application uptime and will fail if the site is down, providing a notification of the issue.